### PR TITLE
fix null Autoscale property for App Service Plan

### DIFF
--- a/infra/core/hosting/app-service-plan.bicep
+++ b/infra/core/hosting/app-service-plan.bicep
@@ -152,7 +152,7 @@ resource autoScaleRule 'Microsoft.Insights/autoscalesettings@2022-10-01' = if (a
               timeWindow: 'PT10M'
               timeAggregation: 'Average'
               operator: 'GreaterThan'
-              threshold: autoScaleSettings!.scaleOutThreshold ?? defaultScaleOutThreshold
+              threshold: autoScaleSettings.?scaleOutThreshold ?? defaultScaleOutThreshold
             }
             scaleAction: {
               direction: 'Increase'
@@ -170,7 +170,7 @@ resource autoScaleRule 'Microsoft.Insights/autoscalesettings@2022-10-01' = if (a
               timeWindow: 'PT10M'
               timeAggregation: 'Average'
               operator: 'LessThan'
-              threshold: autoScaleSettings!.scaleInThreshold ?? defaultScaleInThreshold
+              threshold: autoScaleSettings.?scaleInThreshold ?? defaultScaleInThreshold
             }
             scaleAction: {
               direction: 'Decrease'


### PR DESCRIPTION
Addresses the error
```
Unable to process template language expressions for resource 'foo/providers/Microsoft.Insights/autoscalesettings/asp-common-jzcdzbce3ygqk-autoscale' at line '1' and column '5556'. 'The language expression property 'scaleOutThreshold' doesn't exist, available properties are 'maxCapacity, minCapacity'.'
```