### PR TITLE
Fix race condition for Redis connection

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -491,9 +491,6 @@ module applicationPostConfiguration './modules/application-post-config.bicep' = 
     applicationResourceGroupNamePrimary: resourceGroups.outputs.application_resource_group_name
     applicationResourceGroupNameSecondary: isMultiLocationDeployment ? resourceGroups2.outputs.application_resource_group_name : ''
   }
-  dependsOn: [
-    application
-  ]
 }
 
 /*

--- a/infra/modules/application-post-config.bicep
+++ b/infra/modules/application-post-config.bicep
@@ -124,17 +124,21 @@ var redisCacheSecretNameSecondary = 'App--RedisCache--ConnectionString-Secondary
 
 var multiRegionalSecrets = deploymentSettings.isMultiLocationDeployment ? [redisCacheSecretNameSecondary] : []
 
-var listOfSecretNames = union([
-    azureAdApiClientId
-    azureAdApiInstance
-    azureAdApiScope
-    azureAdApiTenantId
-    azureAdCallbackPath
-    azureAdClientId
-    azureAdClientSecret
-    azureAdInstance
-    azureAdSignedOutCallbackPath
-    azureAdTenantId
+var listOfAppConfigSecrets = [
+  azureAdApiClientId
+  azureAdApiInstance
+  azureAdApiScope
+  azureAdApiTenantId
+  azureAdCallbackPath
+  azureAdClientId
+  azureAdClientSecret
+  azureAdInstance
+  azureAdSignedOutCallbackPath
+  azureAdTenantId
+]
+
+var listOfSecretNames = union(listOfAppConfigSecrets,
+  [
     redisCacheSecretNamePrimary
   ], multiRegionalSecrets)
 
@@ -215,7 +219,7 @@ module writeSecondaryRedisSecret '../core/security/key-vault-secrets.bicep' = if
 // ======================================================================== //
 // Azure AD Application Registration placeholders
 // ======================================================================== //
-module writeAppRegistrationSecrets '../core/security/key-vault-secrets.bicep' = [ for secretName in listOfSecretNames: {
+module writeAppRegistrationSecrets '../core/security/key-vault-secrets.bicep' = [ for secretName in listOfAppConfigSecrets: {
   name: 'write-temp-kv-secret-${secretName}'
   scope: existingKvResourceGroup
   params: {


### PR DESCRIPTION
Fixes the bicep that caused a race condition where the key vault value for the Redis connection string was overriden with `placeholder-populated-by-script`.

The array that was defined was used for two purposes:
- setting a placeholder that could be referenced in other scripts
- defining RBAC access to the secret

The RBAC access settings are preserved for all secrets and from this change we only set initial values for AzureAd settings generated by the `create-app-registrations` script.