### PR TITLE
Reuse blob clients as per Azure best practices

### DIFF
--- a/src/Relecloud.Web.CallCenter.Api/Services/TicketManagementService/TicketImageService.cs
+++ b/src/Relecloud.Web.CallCenter.Api/Services/TicketManagementService/TicketImageService.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All Rights Reserved.
 // Licensed under the MIT License.
 
-using Azure.Identity;
 using Azure.Storage.Blobs;
 
 namespace Relecloud.Web.Api.Services.TicketManagementService
@@ -11,13 +10,14 @@ namespace Relecloud.Web.Api.Services.TicketManagementService
         private readonly ILogger<TicketImageService> logger;
         private readonly BlobContainerClient blobContainerClient;
 
-        public TicketImageService(IConfiguration configuration, ILogger<TicketImageService> logger)
+        public TicketImageService(IConfiguration configuration, BlobServiceClient blobServiceClient, ILogger<TicketImageService> logger)
         {
             this.logger = logger;
 
             // It is best practice to create Azure SDK clients once and reuse them.
-            this.blobContainerClient = new BlobServiceClient(new Uri(configuration["App:StorageAccount:Uri"]), new DefaultAzureCredential())
-                .GetBlobContainerClient(configuration["App:StorageAccount:Container"]);
+            // https://learn.microsoft.com/azure/storage/blobs/storage-blob-client-management#manage-client-objects
+            // https://devblogs.microsoft.com/azure-sdk/lifetime-management-and-thread-safety-guarantees-of-azure-sdk-net-clients/
+            this.blobContainerClient = blobServiceClient.GetBlobContainerClient(configuration["App:StorageAccount:Container"]);
         }
 
         public Task<Stream> GetTicketImagesAsync(string imageName)

--- a/src/Relecloud.Web.CallCenter.Api/Startup.cs
+++ b/src/Relecloud.Web.CallCenter.Api/Startup.cs
@@ -1,6 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All Rights Reserved.
+// Copyright (c) Microsoft Corporation. All Rights Reserved.
 // Licensed under the MIT License.
 
+using Azure.Core;
+using Azure.Identity;
+using Azure.Storage.Blobs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Identity.Web;
 using Microsoft.IdentityModel.Logging;
@@ -142,8 +145,21 @@ namespace Relecloud.Web.Api
         {
             // It is best practice to create Azure SDK clients once and reuse them.
             // https://learn.microsoft.com/azure/storage/blobs/storage-blob-client-management#manage-client-objects
+            // https://devblogs.microsoft.com/azure-sdk/lifetime-management-and-thread-safety-guarantees-of-azure-sdk-net-clients/
             services.AddSingleton<ITicketImageService, TicketImageService>();
+            services.AddSingleton(sp => new BlobServiceClient(new Uri(Configuration["App:StorageAccount:Uri"]), GetAzureCredential()));
         }
+
+        private TokenCredential GetAzureCredential() =>
+            Configuration["App:AzureCredentialType"] switch
+            {
+                "AzureCLI" => new AzureCliCredential(),
+                "Environment" => new EnvironmentCredential(),
+                "ManagedIdentity" => new ManagedIdentityCredential(Configuration["AZURE_CLIENT_ID"]),
+                "VisualStudio" => new VisualStudioCredential(),
+                "VisualStudioCode" => new VisualStudioCodeCredential(),
+                _ => new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = Configuration["AZURE_CLIENT_ID"] }),
+            };
 
         public void Configure(WebApplication app, IWebHostEnvironment env)
         {


### PR DESCRIPTION
Reduces the time to load ticket images (on my dev machine) from ~25 seconds to 320 milliseconds.