### PR TITLE
Update app configuration script to set required Service Bus settings

### DIFF
--- a/src/Relecloud.Messaging/MessageBusOptions.cs
+++ b/src/Relecloud.Messaging/MessageBusOptions.cs
@@ -15,7 +15,7 @@ public class MessageBusOptions
 
     // This property is only required if messages should be generated
     // when ticket images are produced.
-    public string? RenderedTicketQueueName { get; set; }
+    public string? RenderCompleteQueueName { get; set; }
 
     public int MaxRetries { get; set; } = 3;
 

--- a/src/Relecloud.TicketRenderer/TicketRenderRequestMessageHandler.cs
+++ b/src/Relecloud.TicketRenderer/TicketRenderRequestMessageHandler.cs
@@ -31,9 +31,9 @@ internal sealed class TicketRenderRequestMessageHandler(
         }
 
         // If a queue/topic name was specified, use it to publish messages when tickets are rendered.
-        if (!string.IsNullOrEmpty(options.Value.RenderedTicketQueueName))
+        if (!string.IsNullOrEmpty(options.Value.RenderCompleteQueueName))
         {
-            sender = messageBus.CreateMessageSender<TicketRenderCompleteMessage>(options.Value.RenderedTicketQueueName);
+            sender = messageBus.CreateMessageSender<TicketRenderCompleteMessage>(options.Value.RenderCompleteQueueName);
         }
 
         // Initialize the message processor to listen for ticket render requests.

--- a/src/Relecloud.Web.CallCenter.Api/Services/TicketManagementService/TicketRenderCompleteMessageHandler.cs
+++ b/src/Relecloud.Web.CallCenter.Api/Services/TicketManagementService/TicketRenderCompleteMessageHandler.cs
@@ -39,7 +39,7 @@ namespace Relecloud.Web.CallCenter.Api.Services.TicketManagementService
         {
             logger.LogInformation("TicketRenderCompleteMessageHandler is starting");
 
-            var queueName = options.Value.RenderedTicketQueueName;
+            var queueName = options.Value.RenderCompleteQueueName;
 
             if (string.IsNullOrEmpty(queueName))
             {

--- a/tests/Relecloud.Messaging.Tests/MessageBusOptionsTests.cs
+++ b/tests/Relecloud.Messaging.Tests/MessageBusOptionsTests.cs
@@ -13,7 +13,7 @@ public class MessageBusOptionsTests
         var options = new MessageBusOptions
         {
             RenderRequestQueueName = "TestRequestQueue",
-            RenderedTicketQueueName = "TestReponseQueue"
+            RenderCompleteQueueName = "TestReponseQueue"
         };
 
         var context = new ValidationContext(options);
@@ -30,7 +30,7 @@ public class MessageBusOptionsTests
         var options = new MessageBusOptions
         {
             Namespace = "TestNamespace",
-            RenderedTicketQueueName = "TestReponseQueue"
+            RenderCompleteQueueName = "TestReponseQueue"
         };
 
         var context = new ValidationContext(options);
@@ -55,7 +55,7 @@ public class MessageBusOptionsTests
         var isValid = Validator.TryValidateObject(options, context, results, true);
 
         Assert.True(isValid);
-        Assert.Null(options.RenderedTicketQueueName);
+        Assert.Null(options.RenderCompleteQueueName);
         Assert.DoesNotContain(results, r => r.MemberNames.Contains("RenderedTicketQueueName"));
     }
 }

--- a/tests/Relecloud.TicketRenderer.IntegrationTests/TicketRendererFixture.cs
+++ b/tests/Relecloud.TicketRenderer.IntegrationTests/TicketRendererFixture.cs
@@ -34,7 +34,7 @@ public class TicketRendererFixture : WebApplicationFactory<Program>
                 { "App:StorageAccount:Container", "test" },
                 { "App:ServiceBus:Namespace", "test-namespace" },
                 { "App:ServiceBus:RenderRequestQueueName", "test-render-request-queue" },
-                { "App:ServiceBus:RenderedTicketQueueName", "test-rendered-ticket-queue" },
+                { "App:ServiceBus:RenderCompleteQueueName", "test-rendered-ticket-queue" },
             });
         });
 

--- a/tests/Relecloud.TicketRenderer.Tests/TestContext.cs
+++ b/tests/Relecloud.TicketRenderer.Tests/TestContext.cs
@@ -25,7 +25,7 @@ internal class TestContext
             {
                 Namespace = "test-namespace",
                 RenderRequestQueueName = "test-queue",
-                RenderedTicketQueueName = "test-response-queue"
+                RenderCompleteQueueName = "test-response-queue"
             });
 
         Logger = logger

--- a/tests/Relecloud.TicketRenderer.Tests/TicketRenderRequestMessageHandlerTests.cs
+++ b/tests/Relecloud.TicketRenderer.Tests/TicketRenderRequestMessageHandlerTests.cs
@@ -44,7 +44,7 @@ public class TicketRenderRequestMessageHandlerTests
             RenderRequestQueueName = "test-queue",
 
             // Use a response queue name to verify that the sender is instantiated
-            RenderedTicketQueueName = responseQueueName
+            RenderCompleteQueueName = responseQueueName
         });
 
         var ct = new CancellationToken();
@@ -78,7 +78,7 @@ public class TicketRenderRequestMessageHandlerTests
             RenderRequestQueueName = "test-queue",
 
             // Use a response queue name to verify that the sender is instantiated
-            RenderedTicketQueueName = responseQueueName
+            RenderCompleteQueueName = responseQueueName
         });
 
         var context = new TestContext(options: options);
@@ -125,7 +125,7 @@ public class TicketRenderRequestMessageHandlerTests
             RenderRequestQueueName = "test-queue",
 
             // Use a response queue name to verify that the sender is instantiated
-            RenderedTicketQueueName = responseQueueName
+            RenderCompleteQueueName = responseQueueName
         });
 
         var context = new TestContext(options: options);
@@ -155,7 +155,7 @@ public class TicketRenderRequestMessageHandlerTests
             RenderRequestQueueName = "test-queue",
 
             // Use a response queue name to verify that the sender is instantiated
-            RenderedTicketQueueName = responseQueueName
+            RenderCompleteQueueName = responseQueueName
         });
 
         var ct = new CancellationToken();

--- a/tests/Relecloud.Web.CallCenter.Api.Tests/TicketRenderCompleteMessageHandlerTests.cs
+++ b/tests/Relecloud.Web.CallCenter.Api.Tests/TicketRenderCompleteMessageHandlerTests.cs
@@ -13,7 +13,7 @@ public class TicketRenderCompleteMessageHandlerTests
     public async Task StartAsync_ShouldSubscribeToMessageBus_WhenQueueNameIsNotNullOrEmpty(string queueName)
     {
         // Arrange
-        var options = Options.Create(new MessageBusOptions { RenderedTicketQueueName = queueName });
+        var options = Options.Create(new MessageBusOptions { RenderCompleteQueueName = queueName });
         var ct = new CancellationToken();
         var serviceProvider = new ServiceCollection().BuildServiceProvider();
         var logger = Substitute.For<ILogger<TicketRenderCompleteMessageHandler>>();
@@ -52,7 +52,7 @@ public class TicketRenderCompleteMessageHandlerTests
         Func<TicketRenderCompleteMessage, CancellationToken, Task>? messageHandler = null;
 
         var ct = new CancellationToken();
-        var options = Options.Create(new MessageBusOptions { RenderedTicketQueueName = "test-queue" });
+        var options = Options.Create(new MessageBusOptions { RenderCompleteQueueName = "test-queue" });
         var logger = Substitute.For<ILogger<TicketRenderCompleteMessageHandler>>();
 
         var messageBus = Substitute.For<IMessageBus>();
@@ -87,7 +87,7 @@ public class TicketRenderCompleteMessageHandlerTests
         // Arrange
         var serviceProvider = Substitute.For<IServiceProvider>();
         var logger = Substitute.For<ILogger<TicketRenderCompleteMessageHandler>>();
-        var options = Options.Create(new MessageBusOptions { RenderedTicketQueueName = "test-queue" });
+        var options = Options.Create(new MessageBusOptions { RenderCompleteQueueName = "test-queue" });
         var processor = Substitute.For<IMessageProcessor>();
         var messageBus = Substitute.For<IMessageBus>();
         messageBus.SubscribeAsync(
@@ -114,7 +114,7 @@ public class TicketRenderCompleteMessageHandlerTests
         // Arrange
         var serviceProvider = Substitute.For<IServiceProvider>();
         var logger = Substitute.For<ILogger<TicketRenderCompleteMessageHandler>>();
-        var options = Options.Create(new MessageBusOptions { RenderedTicketQueueName = "test-queue" });
+        var options = Options.Create(new MessageBusOptions { RenderCompleteQueueName = "test-queue" });
         var processor = Substitute.For<IMessageProcessor>();
         var messageBus = Substitute.For<IMessageBus>();
         messageBus.SubscribeAsync(


### PR DESCRIPTION
Complete bicep updates for the ticket rendering service are still a WIP, but this updates the app configuration script to at least set necessary config settings and feature flags in Azure App Configuration so the deployment will continue to work.

These changes default the feature flag for using the distributed ticket rendering service to 'false' for now until those infrastructure-as-code updates are done (at which point, the default will flip to 'true').