### PR TITLE
Fix null reference exception and add user creation

### DIFF
--- a/src/Relecloud.Web.CallCenter.Api/Controllers/TicketController.cs
+++ b/src/Relecloud.Web.CallCenter.Api/Controllers/TicketController.cs
@@ -95,7 +95,7 @@ namespace Relecloud.Web.Api.Controllers
                 var errors = new List<string>();
                 if (purchaseTicketRequest == null)
                 {
-                    errors.Add("Missing required payment details");
+                    errors.Add("Purchase ticket request must not be null");
                 }
                 else
                 {


### PR DESCRIPTION
If there was an error during deployment then the user may have been able to login before the API was successfully started. This causes an error during checkout because of a referential constraint on the User table.

Calling createOrUpdateUser during checkout ensures the integrity of the relationship.