### PR TITLE
Add Docker to dev container to enable deploying containerized services

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,8 @@
 		"ghcr.io/devcontainers/features/common-utils:2": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers/features/powershell:1": {},
-		"ghcr.io/devcontainers/features/sshd:1": {}
+		"ghcr.io/devcontainers/features/sshd:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
 	// resolves error: dubious ownership of the workspace folder
 	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"


### PR DESCRIPTION
Now that MWA includes services like the ticket renderer that are deployed in Docker containers, the solution's dev container needs Docker installed in order to build and deploy.