### PR TITLE
Add error handling during the creation of Entra ID App Registration

### DIFF
--- a/infra/scripts/postprovision/create-app-registrations.ps1
+++ b/infra/scripts/postprovision/create-app-registrations.ps1
@@ -472,7 +472,7 @@ try {
 } catch {
     $errorMessage = $_.Exception.Message
     Write-Warning "An error occurred saving $highlightColor'MicrosoftEntraId--ClientSecret'$defaultColor to Key Vault: $errorMessage"
-    Write-WWarning "Please save the client secret manually or users will not be able to make authenticated requests to the web API during checkout."
+    Write-Warning "Please save the client secret manually or users will not be able to make authenticated requests to the web API during checkout."
 }
 
 # Get or Create the api app registration


### PR DESCRIPTION
If this command to save a client_secret were to fail then the script would exit with failure. The result would prevent the reader from being able to create the 2nd App Registration which is required to successfully boot strap the web api project.

With this update:
- Flow remains unchanged if there is no error.
- If there is an error it will be treated as a warning. The impact to the reader is that they would only be able to perform unauthenticated actions until the client_secret is saved to Key Vault.