### PR TITLE
Upgrade to AZD 1.10.1 and specify explicit ACA version when deploying

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,14 +2,14 @@
 	"name": "web-app-pattern-dotnet",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"args": { 
+		"args": {
 			"VARIANT": "8.0-bookworm"
 		}
 	},
 	"runArgs": ["--init", "--privileged"],
 
 	"customizations": {
-		"vscode": {	
+		"vscode": {
 			"extensions": [
 				"ms-azuretools.azure-dev",
 				"ms-azuretools.vscode-azureappservice",
@@ -35,7 +35,7 @@
 			//  - /.github/workflows/azure-dev.yml
 			//  - /.github/workflows/scheduled-azure-dev.yml
 			//  - /.github/workflows/scheduled-azure-teardown.yml
-			"version": "1.9.5"
+			"version": "1.10.1"
 		},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"version": "latest"

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -12,11 +12,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/azure-dev-cli-apps:1.9.5
+      image: mcr.microsoft.com/azure-dev-cli-apps:1.10.1
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
+
       # login to run ado commands such provision, deploy, and down
       - name: Log in with Azure (Client Credentials)
         if: ${{ env.AZURE_CREDENTIALS != '' }}
@@ -31,7 +31,7 @@ jobs:
         shell: pwsh
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-          
+
       - name: Azure Dev Provision
         run: azd provision --no-prompt
         env:

--- a/.github/workflows/scheduled-azure-dev.yml
+++ b/.github/workflows/scheduled-azure-dev.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/azure-dev-cli-apps:1.9.5
+      image: mcr.microsoft.com/azure-dev-cli-apps:1.10.1
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -40,7 +40,7 @@ jobs:
       - name: Check configuration
         if: ${{ env.AZURE_CLIENT_ID == '' }}
         run: echo "AZURE_CLIENT_ID are not available."
-        
+
       # login to run ado commands such provision, deploy, and down
       - name: Log in with Azure (Federated Credentials)
         if: ${{ env.AZURE_CLIENT_ID != '' }}
@@ -50,7 +50,7 @@ jobs:
             --federated-credential-provider "github" `
             --tenant-id "$Env:AZURE_TENANT_ID" `
         shell: pwsh
-        
+
       # login to run azd hooks and the QA validation script
       - name: Log in with Azure CLI
         if: ${{ env.AZURE_CLIENT_ID != '' }}

--- a/.github/workflows/scheduled-azure-teardown.yml
+++ b/.github/workflows/scheduled-azure-teardown.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 13 1 * *' # Run at 13:00 on the 1st day of the month
-    
+
 # https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Clinux#set-up-azure-login-with-openid-connect-authentication
 permissions:
   id-token: write
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/azure-dev-cli-apps:1.9.5
+      image: mcr.microsoft.com/azure-dev-cli-apps:1.10.1
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -35,7 +35,7 @@ jobs:
       - name: Install Az module
         run: Install-Module -Name Az -Force -AllowClobber -Scope CurrentUser -Repository PSGallery
         shell: pwsh
-        
+
       # login to run ado commands such provision, deploy, and down
       - name: Log in with Azure (Federated Credentials)
         if: ${{ env.AZURE_CLIENT_ID != '' }}
@@ -45,7 +45,7 @@ jobs:
             --federated-credential-provider "github" `
             --tenant-id "$Env:AZURE_TENANT_ID" `
         shell: pwsh
-        
+
       # login to run azd hooks and the QA validation script
       - name: Log in with Azure CLI
         if: ${{ env.AZURE_CLIENT_ID != '' }}

--- a/azure.yaml
+++ b/azure.yaml
@@ -56,6 +56,7 @@ services:
     project: src/Relecloud.TicketRenderer
     language: dotnet
     host: containerapp
+    apiVersion: 2024-02-02-preview # Force `azd` to use this API version for GET/PATCH operations
     docker:
       # These paths are relative to the project directory
       path: ./Dockerfile

--- a/infra/core/compute/postDeploymentScript/post-deployment.sh
+++ b/infra/core/compute/postDeploymentScript/post-deployment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # install AZD - keep this version in sync with the version used in the file /.devcontainer/devcontainer.json file
-curl -fsSL https://aka.ms/install-azd.sh | bash -s -- -- version 1.9.5
+curl -fsSL https://aka.ms/install-azd.sh | bash -s -- -- version 1.10.1
 
 # add Microsoft package feed for the dotnet install
 # Get Ubuntu version


### PR DESCRIPTION
Updates AZD to a version that supports specifying the ACA version needed at deploy-time in order to support managed identity auth in ACA scale rules.