### PR TITLE
Update "prerequisites.md" to align with "global.json"

### DIFF
--- a/prerequisites.md
+++ b/prerequisites.md
@@ -51,8 +51,8 @@ The following tools are pre-requisites to running the associated deployment step
     azd version
     ```
 
-1. [Install .NET 7 SDK](https://dotnet.microsoft.com/download/dotnet/7.0)
-    Run the following command to verify that the .NET SDK 7.0 is installed.
+1. [Install .NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+    Run the following command to verify that the .NET SDK 8.0 is installed.
     ```ps1
     dotnet --version
     ```


### PR DESCRIPTION
The `global.json` requires .NET 8 SDK to be installed:
https://github.com/Azure/modern-web-app-pattern-dotnet/blob/831d587f8f47c5099e38d1b4a9255a6325d10073/global.json#L6

Thus, this should be aligned with `prerequisites.md`